### PR TITLE
Task/mt 7163 translaions support

### DIFF
--- a/Sources/W3WSwiftCore/Bridges/ApiExtension.swift
+++ b/Sources/W3WSwiftCore/Bridges/ApiExtension.swift
@@ -13,10 +13,8 @@
 import Foundation
 
 #if canImport(w3w)
-import w3w
-
-
 #if canImport(W3WSwiftApi)
+import w3w
 
 
 extension W3WProtocolV4 {

--- a/Sources/W3WSwiftCore/Bridges/ApiExtension.swift
+++ b/Sources/W3WSwiftCore/Bridges/ApiExtension.swift
@@ -12,6 +12,8 @@
 
 import Foundation
 
+#if !IMESSAGE
+#if !os(watchOS)
 #if canImport(w3w)
 #if canImport(W3WSwiftApi)
 import w3w
@@ -81,6 +83,6 @@ extension W3WProtocolV4 {
 
 
 #endif
-
-
+#endif
+#endif
 #endif

--- a/Sources/W3WSwiftCore/Bridges/SdkExtension.swift
+++ b/Sources/W3WSwiftCore/Bridges/SdkExtension.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 
+#if !IMESSAGE
+#if !os(watchOS)
 #if canImport(w3w)
 import w3w
 
@@ -195,4 +197,6 @@ extension What3Words: W3WProtocolV4 {
 }
 
 
+#endif
+#endif
 #endif

--- a/Sources/W3WSwiftCore/Bridges/SdkTypes.swift
+++ b/Sources/W3WSwiftCore/Bridges/SdkTypes.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 
+#if !IMESSAGE
+#if !os(watchOS)
 #if canImport(w3w)
 import w3w
 
@@ -50,4 +52,6 @@ public extension W3WSdkSuggestion {
   }
 }
 
+#endif
+#endif
 #endif

--- a/Sources/W3WSwiftCore/Localization/W3WMockTranslation.swift
+++ b/Sources/W3WSwiftCore/Localization/W3WMockTranslation.swift
@@ -8,8 +8,14 @@
 import Foundation
 
 public class W3WMockTranslation: W3WTranslationsProtocol {
+  
   public init() {}
+
   public func get(id: String) -> String {
-    ""
+    return id
+  }
+  
+  public func get(id: String, language: (any W3WLanguage)?) -> String {
+    return id
   }
 }

--- a/Sources/W3WSwiftCore/Localization/W3WTranslationsProtocol.swift
+++ b/Sources/W3WSwiftCore/Localization/W3WTranslationsProtocol.swift
@@ -8,6 +8,24 @@
 
 public protocol W3WTranslationsProtocol {
   
+  /// given a translation id return the translation for the given device locale
+  /// - Parameters:
+  ///     - id: a translation id
   func get(id: String) -> String
+  
+  /// given a translation id return the translation for the given device locale
+  /// - Parameters:
+  ///     - id: a translation id
+  ///     - language: the language to translate into
+  func get(id: String, language: W3WLanguage?) -> String
+  
+}
+
+
+public extension W3WTranslationsProtocol {
+  
+  func get(id: String) -> String {
+    return get(id: id, language: nil)
+  }
   
 }

--- a/Tests/w3w-swift-typesTests/w3w_swift_typesTests.swift
+++ b/Tests/w3w-swift-typesTests/w3w_swift_typesTests.swift
@@ -35,6 +35,33 @@ final class w3w_swift_typesTests: XCTestCase {
   }
   
   
+  func testDeviceLangauges() {
+    let languages = W3WBaseLanguage.english.getDeviceLanguages()
+    print(languages)
+    
+    let assamese = languages.first(where: { lang in lang.locale == "as_IN" }) as? W3WBaseLanguage
+    XCTAssertTrue(assamese!.name!.contains("Assamese"))
+    XCTAssertTrue(assamese!.name!.contains("India"))
+    XCTAssertTrue(assamese!.nativeName!.contains("অসমীয়া"))
+    XCTAssertTrue(assamese!.code == "as")
+  }
+  
+  
+  func testLanguageNames() {
+    let french = W3WBaseLanguage(locale: "fr_ca")
+    XCTAssertTrue(french.name!.contains("French"))
+    XCTAssertTrue(french.nativeName!.contains("français"))
+    XCTAssertTrue(french.nativeName!.contains("Canada"))
+
+    let frenchfrench = W3WBaseLanguage(locale: "fr")
+    XCTAssertTrue(frenchfrench.name == "French")
+    XCTAssertTrue(frenchfrench.nativeName == "français")
+    
+    XCTAssertTrue(W3WBaseLanguage.english.name!.contains("English"))
+    XCTAssertTrue(W3WBaseLanguage.english.nativeName!.contains("English"))
+  }
+  
+  
   func testOptions() throws {
     
     //let custom1  = W3WOption(key: "yyy", value: "yyy")


### PR DESCRIPTION
W3WBaseLangauge constructor wasn't working with RFC 5646 locales.  This fixes it, and adds functions that return language names from locale codes.