### PR TITLE
MT-7890 Fix not updating distance unit OCR on changing distanceUnit

### DIFF
--- a/Sources/W3WSwiftCore/Types/Geometry/W3WDistance.swift
+++ b/Sources/W3WSwiftCore/Types/Geometry/W3WDistance.swift
@@ -63,30 +63,37 @@ public extension W3WDistance {
     return nil
   }
   
-  
+  /// 12,000km or 12,000mi, etc...
   var description: String {
-    var distance = ""
-    
-    let formatter = MKDistanceFormatter()
-    formatter.unitStyle = .abbreviated
-    
-    
-    // if it is metric
-    if W3WSettings.measurement == .metric {
-      formatter.units = .metric
-      
-    // if it is imperial
-    } else if W3WSettings.measurement == .imperial {
-      formatter.units = .imperial
-
-    // otherwise use the system default
-    } else {
-      formatter.units = (getDefaultMeasurementSystem() == .metric) ? .metric : .imperial
+    let mileSuffix = "mi"
+    let kmSuffix = "km"
+    var suffix = ""
+    var finalDistance: Double = 0.0
+    switch W3WSettings.measurement {
+    case .imperial:
+      suffix = mileSuffix
+      finalDistance = miles
+    case .metric:
+      suffix = kmSuffix
+      finalDistance = kilometers
+    case .system:
+      suffix = getDefaultMeasurementSystem() == .imperial ? mileSuffix : kmSuffix
+      finalDistance = getDefaultMeasurementSystem() == .imperial ? miles : kilometers
     }
-
-    distance = formatter.string(fromDistance: meters)
     
-    return distance
+    if finalDistance < 0.01 {
+      return "<" + W3WSettings.separatorType.getFormattedString(for: 0.01) + suffix
+    }
+    
+    if finalDistance >= 1 {
+      return W3WSettings.separatorType.getFormattedString(for: finalDistance.rounded()) + suffix
+    }
+    
+    var stringFinalDistance = W3WSettings.separatorType.getFormattedString(for: finalDistance)
+    if stringFinalDistance.count > 4 {
+      stringFinalDistance = String(stringFinalDistance.prefix(4))
+    }
+    return stringFinalDistance + suffix
   }
   
   

--- a/Sources/W3WSwiftCore/Types/Util/W3WMeasurementSystem.swift
+++ b/Sources/W3WSwiftCore/Types/Util/W3WMeasurementSystem.swift
@@ -14,3 +14,39 @@ public enum W3WMeasurementSystem {
   case imperial
   case system
 }
+
+public enum W3WSeparatorsType {
+  case firstCommaSecondDot
+  case firstDotSecondComma
+  case firstSpaceSecondDot
+  case firstSpaceSecondComma
+  case firstWithoutSecondDot
+  case firstWithoutSecondComma
+    
+  /// 12,000 or 12.000 or 12 000, etc..
+  public func getFormattedString(for value: Double) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    switch self {
+    case .firstCommaSecondDot:
+      formatter.groupingSeparator = ","
+      formatter.decimalSeparator = "."
+    case .firstSpaceSecondComma:
+      formatter.groupingSeparator = " "
+      formatter.decimalSeparator = ","
+    case .firstDotSecondComma:
+      formatter.groupingSeparator = "."
+      formatter.decimalSeparator = ","
+    case .firstSpaceSecondDot:
+      formatter.groupingSeparator = " "
+      formatter.decimalSeparator = "."
+    case .firstWithoutSecondDot:
+      formatter.groupingSeparator = ""
+      formatter.decimalSeparator = "."
+    case .firstWithoutSecondComma:
+      formatter.groupingSeparator = ""
+      formatter.decimalSeparator = ","
+    }
+    return formatter.string(for: value) ?? String(value)
+  }
+}

--- a/Sources/W3WSwiftCore/W3WSettings+W3WSwiftCore.swift
+++ b/Sources/W3WSwiftCore/W3WSettings+W3WSwiftCore.swift
@@ -11,6 +11,8 @@ public struct W3WSettings {
   
   // mutable settings
   static public var measurement = W3WMeasurementSystem.system
+  
+  static public var separatorType = W3WSeparatorsType.firstCommaSecondDot
 
   // direction of writing
   static public var leftToRight = (NSLocale.characterDirection(forLanguage: NSLocale.preferredLanguages.first ?? W3WSettings.defaultLanguage.code) == Locale.LanguageDirection.leftToRight)


### PR DESCRIPTION
Issue: - Mismatch distance unit in OCR bottomsheet and main app 
Update: 
- Add `W3WSeparatorsType ` to `W3WSettings` to handle different `, . ` variations in strings
- Update logic format distance string