### PR TITLE
Add W3WRfcLanguage API with iOSCompatibile

### DIFF
--- a/Sources/W3WSwiftCore/Localization/W3WTranslationsProtocol.swift
+++ b/Sources/W3WSwiftCore/Localization/W3WTranslationsProtocol.swift
@@ -18,17 +18,6 @@ public protocol W3WTranslationsProtocol: W3WAvailableLanguageProtocol {
   ///     - id: a translation id
   ///     - language: the language to translate into
   func get(id: String, language: W3WLanguage?) -> String
-  
-}
-
-public protocol W3WLanguageSelectionProtocol  {
-  /// to set RFCLanguage
-  func set(language: W3WRfcLanguage)
-}
-
-/// list out all available RFCLanguages
-public protocol W3WAvailableLanguageProtocol {
-  func availableLanguages() -> [W3WRfcLanguage]
 }
 
 public extension W3WTranslationsProtocol {
@@ -49,12 +38,5 @@ public extension W3WTranslationsProtocol {
   func get(id: String, _ arguments: CVarArg...) -> String {
     let localized = get(id: id)
     return String(format: localized, arguments)
-  }
-}
-
-public extension W3WAvailableLanguageProtocol {
-  /// default convenience func for available languages, should override when in need
-  func availableLanguages() -> [W3WRfcLanguage] {
-    return []
   }
 }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
@@ -51,9 +51,9 @@ public struct W3WRfcLanguage: W3WRfcLanguageProtocol {
     regionCode: String? = nil,
     iOSCompatible: Bool
   ) throws {
-    let string = [code, scriptCode, regionCode].compactJoined()
     // 1. Validate only if iOS compatibility is required
     if iOSCompatible {
+      let string = [code, scriptCode, regionCode].compactJoined()
       try Self.validateiOSCompatibility(identifier: string)
     }
     self.code = code

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
@@ -60,7 +60,7 @@ public extension W3WRfcLanguage {
       .trimmingCharacters(in: .whitespacesAndNewlines)
       .replacingOccurrences(of: "_", with: "-")
     
-    // Handle “Base” or empty strings, check if string is a valid locale string
+    // Check not empty string
     guard !normalized.isEmpty else {
       self.init(code: nil, scriptCode: nil, regionCode: nil)
       return

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
@@ -43,6 +43,24 @@ public struct W3WRfcLanguage: W3WRfcLanguageProtocol {
     self.regionCode = regionCode
   }
   
+  /// if you want to init and validate that the language is supported on os, set `iOSCompatible` = `true`, or else = `false`
+  /// if it's not valid, an error will be thrown
+  public init(
+    code: String? = nil,
+    scriptCode: String? = nil,
+    regionCode: String? = nil,
+    iOSCompatible: Bool
+  ) throws {
+    let string = [code, scriptCode, regionCode].compactJoined()
+    // 1. Validate only if iOS compatibility is required
+    if iOSCompatible {
+      try Self.validateiOSCompatibility(identifier: string)
+    }
+    self.code = code
+    self.scriptCode = scriptCode
+    self.regionCode = regionCode
+  }
+  
   @available(iOS 16, *)
   @available(watchOS 9, *)
   public init(from language: Locale.Language) {
@@ -53,6 +71,15 @@ public struct W3WRfcLanguage: W3WRfcLanguageProtocol {
 }
 
 public extension W3WRfcLanguage {
+  /// if you want to init and validate that the language is supported on os, set `iOSCompatible` = `true`, or else = `false`
+  /// if it's not valid, an error will be thrown
+  init(from string: String, iOSCompatible: Bool) throws {
+    if iOSCompatible {
+      try Self.validateiOSCompatibility(identifier: string)
+    }
+    
+    self.init(from: string)
+  }
   /// Initialize from a string
   init(from string: String) {
     // Normalize separators
@@ -98,38 +125,6 @@ public extension W3WRfcLanguage {
   }
 }
 
-public extension W3WRfcLanguageProtocol {
-  /// full version: code - script - region
-  var identifier: String {
-    return [code, scriptCode, regionCode]
-      .compactMap { $0 }
-      .joined(separator: "-")
-  }
-  /// short : code - region
-  var shortIdentifier: String {
-    return [code, regionCode]
-      .compactMap { $0 }
-      .joined(separator: "-")
-  }
-  
-  func direction() -> W3WWritingDirection {
-    switch NSLocale.characterDirection(forLanguage: identifier) {
-      case .unknown:
-        return .leftToRight
-      case .leftToRight:
-        return .leftToRight
-      case .rightToLeft:
-        return .rightToLeft
-      case .topToBottom:
-        return .topToBottom
-      case .bottomToTop:
-        return .bottomToTop
-      @unknown default:
-        return .leftToRight
-    }
-  }
-}
-
 @available(watchOS 9, *)
 @available(iOS 16, *)
 extension Locale.Language : W3WRfcLanguageProtocol {
@@ -168,3 +163,4 @@ extension W3WRfcLanguage {
     return name(in: language.identifier)
   }
 }
+

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
@@ -147,6 +147,9 @@ extension Locale.Language : W3WRfcLanguageProtocol {
 }
 
 extension W3WRfcLanguage {
+  /// this is returned correctly as long as OS recognizes the language code,
+  /// or else it will be the name in English (the same as name below)
+  /// this can happen as we have some sdk languages which are not supported by OS, ex: mn-Latn
   public var nativeName: String? {
     return LanguageUtils.getLanguageName(forLocale: identifier, inLocale: identifier)
   }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguage.swift
@@ -61,7 +61,7 @@ public extension W3WRfcLanguage {
       .replacingOccurrences(of: "_", with: "-")
     
     // Handle “Base” or empty strings, check if string is a valid locale string
-    guard !normalized.isEmpty, string.isValidLocale else {
+    guard !normalized.isEmpty else {
       self.init(code: nil, scriptCode: nil, regionCode: nil)
       return
     }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocol.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocol.swift
@@ -13,8 +13,78 @@ public protocol W3WRfcLanguageProtocol: Equatable {
   var regionCode: String? { get }
 }
 
+public extension W3WRfcLanguageProtocol {
+  // validate if language is supported by os, or else throw error
+  static func validateiOSCompatibility(identifier: String) throws {
+    let isValid: Bool
+    if #available(iOS 16, watchOS 9, *) {
+      let language = Locale.Language(identifier: identifier)
+      let langCode = language.code ?? ""
+      
+      // Check if code exists and is either equivalent to a standard locale or passes custom validation
+      isValid = !langCode.isEmpty &&
+      (language.isEquivalent(to: .init(identifier: langCode)) || identifier.isValidLocale)
+    } else {
+      isValid = identifier.isValidLocale
+    }
+    
+    if !isValid {
+      throw W3WError.other(LanguageError.languageNotSupportedByOS)
+    }
+  }
+}
+
+public extension W3WRfcLanguageProtocol {
+  /// full version: code - script - region
+  var identifier: String {
+    return [code, scriptCode, regionCode].compactJoined()
+      
+  }
+  /// short : code - region
+  var shortIdentifier: String {
+    return [code, regionCode].compactJoined()
+  }
+  
+  var iOSCompatible: Bool {
+    do {
+      try Self.validateiOSCompatibility(identifier: identifier)
+      return true
+    } catch {
+      return false
+    }
+  }
+  
+  func direction() -> W3WWritingDirection {
+    switch NSLocale.characterDirection(forLanguage: identifier) {
+      case .unknown:
+        return .leftToRight
+      case .leftToRight:
+        return .leftToRight
+      case .rightToLeft:
+        return .rightToLeft
+      case .topToBottom:
+        return .topToBottom
+      case .bottomToTop:
+        return .bottomToTop
+      @unknown default:
+        return .leftToRight
+    }
+  }
+}
+
+public enum LanguageError: Error {
+  case languageNotSupportedByOS
+}
+
 /// protocol to convert any language to W3WRfcLanguage
 public protocol W3WRfcLanguageConvertable<Language> {
   associatedtype Language: W3WRfcLanguageProtocol
   func toRfcLanguage() -> Language
 }
+
+extension Sequence where Element == String? {
+  func compactJoined(separator: String = "-") -> String {
+    return self.compactMap { $0 }.joined(separator: separator)
+  }
+}
+

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
@@ -1,0 +1,25 @@
+//
+//  W3WRfcLanguageProtocols.swift
+//  w3w-swift-core
+//
+//  Created by Kaley Nguyen on 2/2/26.
+//
+
+import Foundation
+
+public protocol W3WLanguageSelectionProtocol  {
+  /// to set RFCLanguage
+  func set(language: W3WRfcLanguage)
+}
+
+/// list out all available RFCLanguages
+public protocol W3WAvailableLanguageProtocol {
+  func availableLanguages() -> [W3WRfcLanguage]
+}
+
+public extension W3WAvailableLanguageProtocol {
+  /// default convenience func for available languages, should override when in need
+  func availableLanguages() -> [W3WRfcLanguage] {
+    return []
+  }
+}

--- a/Sources/W3WSwiftCore/Types/Util/LanguageUtils.swift
+++ b/Sources/W3WSwiftCore/Types/Util/LanguageUtils.swift
@@ -30,6 +30,18 @@ public class LanguageUtils {
 extension String {
   var isValidLocale: Bool {
     let normalized = self.replacingOccurrences(of: "-", with: "_")
-    return Locale.availableIdentifiers.contains(normalized)
+    /// 1. Direct check
+    if Locale.availableIdentifiers.contains(normalized) {
+      return true
+    }
+    /// 2. Fallback: Strip the script code and check again
+    /// Ex: en_Latn_IN -> en_IN
+    let components = Locale.components(fromIdentifier: normalized)
+    if let language = components[NSLocale.Key.languageCode.rawValue], let region = components[NSLocale.Key.countryCode.rawValue] {
+      let shortIdentifier = "\(language)_\(region)"
+      return Locale.availableIdentifiers.contains(shortIdentifier)
+    }
+    
+    return false
   }
 }

--- a/Tests/languages-Tests/W3wRfcLanguage_w3wLanguage_tests.swift
+++ b/Tests/languages-Tests/W3wRfcLanguage_w3wLanguage_tests.swift
@@ -6,7 +6,9 @@
 //
 
 import Testing
+import Foundation
 @testable import W3WSwiftCore
+#if canImport(w3w)
 import w3w
 
 @Suite
@@ -143,3 +145,5 @@ struct W3wRfcLanguage_W3wLanguage_Tests {
     #expect(rfcLang.regionCode == nil)
   }
 }
+
+#endif

--- a/Tests/languages-Tests/W3wRfcLanguage_w3wSdkLanguage_tests.swift
+++ b/Tests/languages-Tests/W3wRfcLanguage_w3wSdkLanguage_tests.swift
@@ -6,7 +6,9 @@
 //
 
 import Testing
+import Foundation
 @testable import W3WSwiftCore
+#if canImport(w3w)
 import w3w
 
 @Suite
@@ -87,3 +89,4 @@ struct W3wRfcLanguage_W3wSdkLanguage_Tests {
   }
 }
 
+#endif

--- a/Tests/languages-Tests/w3wRfcLanguage_tests.swift
+++ b/Tests/languages-Tests/w3wRfcLanguage_tests.swift
@@ -11,6 +11,8 @@ import Foundation
 
 @Suite
 struct w3wRfcLanguage_tests {
+  // these languages are not supported by iOS
+  let exceptions = ["mn-Latn", "kk-Latn"]
   
   @Test func initRfcLanguage() async throws {
     let lang = W3WRfcLanguage(locale: Locale(identifier: "fr-FR"))
@@ -18,45 +20,120 @@ struct w3wRfcLanguage_tests {
     #expect(lang.nativeName == "français (France)")
     #expect(lang.name == "French (France)")
     #expect(lang.name(in: "ja") == "フランス語 (フランス)")
+    #expect(lang.iOSCompatible)
   }
   
-  @Test func initRfcLanguage_changeDefault() async throws {
-    let lang = W3WRfcLanguage(locale: Locale(identifier: "fr-FR"))
-    #expect(lang.code == "fr")
-  }
-  
-  @Test func initRfcLanguage_Exceptions_Mongolian() async throws {
+  @Test func initRfcLanguage_Exception_NoValidation() {
     let lang1 = W3WRfcLanguage(from: "mn-Latn")
     #expect(lang1.code == "mn")
     #expect(lang1.name == "Mongolian")
     #expect(lang1.scriptCode == "Latn")
+    #expect(!lang1.iOSCompatible)
     
     let lang2 = W3WRfcLanguage(from: "mn-Cyrl")
     #expect(lang2.code == "mn")
     #expect(lang2.name == "Mongolian")
     #expect(lang2.scriptCode == "Cyrl")
+    #expect(lang2.iOSCompatible)
     
     let lang3 = W3WRfcLanguage(from: "mn")
     #expect(lang3.code == "mn")
     #expect(lang3.name == "Mongolian")
     #expect(lang3.scriptCode == "Cyrl")
+    #expect(lang2.iOSCompatible)
+    
+    let lang4 = W3WRfcLanguage(from: "kk-Cyrl")
+    #expect(lang4.code == "kk")
+    #expect(lang4.name == "Kazakh")
+    #expect(lang4.scriptCode == "Cyrl")
+    #expect(lang4.iOSCompatible)
+    
+    let lang5 = W3WRfcLanguage(from: "kk-Latn")
+    #expect(lang5.code == "kk")
+    #expect(lang5.name == "Kazakh")
+    #expect(lang5.scriptCode == "Latn")
+    #expect(!lang5.iOSCompatible)
+    
+    let lang6 = W3WRfcLanguage(from: "kk")
+    #expect(lang6.code == "kk")
+    #expect(lang6.name == "Kazakh")
+    #expect(lang6.scriptCode == "Cyrl")
+    #expect(lang6.iOSCompatible)
+    
+    // language with any random code that matches the format
+    let lang7 = W3WRfcLanguage(code: "kk", scriptCode: "iost")
+    #expect(lang7.code == "kk")
+    #expect(lang7.scriptCode == "iost")
+    #expect(!lang7.iOSCompatible)
   }
   
-  @Test func initRfcLanguage_Exceptions_Kazakh() async throws {
-    let lang1 = W3WRfcLanguage(from: "kk-Cyrl")
-    #expect(lang1.code == "kk")
-    #expect(lang1.name == "Kazakh")
+  @Test func initRfcLanguage_Exceptions_CheckiOSCompatible_Error() throws {
+    // throw error when language is not supported
+    #expect(throws: W3WError.other(LanguageError.languageNotSupportedByOS)) {
+      _ = try W3WRfcLanguage(from: "mn-Latn", iOSCompatible: true)
+    }
+    
+    #expect(throws: W3WError.other(LanguageError.languageNotSupportedByOS)) {
+      _ = try W3WRfcLanguage(code: "mn", scriptCode: "Latn", iOSCompatible: true)
+    }
+  }
+  
+  /// some languages' codes are different but they are the same language
+  @Test func initRfcLanguage_SameLanguageDifferentCode_CheckiOSCompatible_Success() throws {
+    // code = mn, script = Cyrl
+    let lang1 = try W3WRfcLanguage(from: "mn-Cyrl", iOSCompatible: true)
+    #expect(lang1.code == "mn")
+    #expect(lang1.name == "Mongolian")
     #expect(lang1.scriptCode == "Cyrl")
     
-    let lang2 = W3WRfcLanguage(from: "kk-Latn")
-    #expect(lang2.code == "kk")
-    #expect(lang2.name == "Kazakh")
-    #expect(lang2.scriptCode == "Latn")
+    let lang2 = try W3WRfcLanguage(code: "mn", scriptCode: "Cyrl", iOSCompatible: true)
+    #expect(lang2.code == "mn")
+    #expect(lang2.name == "Mongolian")
+    #expect(lang2.scriptCode == "Cyrl")
     
-    let lang3 = W3WRfcLanguage(from: "kk")
-    #expect(lang3.code == "kk")
-    #expect(lang3.name == "Kazakh")
+    let lang3 = try W3WRfcLanguage(from: "mn", iOSCompatible: true)
+    #expect(lang3.code == "mn")
+    #expect(lang3.name == "Mongolian")
     #expect(lang3.scriptCode == "Cyrl")
+    
+    //2. code = kk, script = Cyrl
+    let lang4 = try W3WRfcLanguage(from: "kk-Cyrl", iOSCompatible: true)
+    #expect(lang4.code == "kk")
+    #expect(lang4.scriptCode == "Cyrl")
+    
+    let lang5 = try W3WRfcLanguage(code: "kk", scriptCode: "Cyrl", iOSCompatible: true)
+    #expect(lang5.code == "kk")
+    #expect(lang5.scriptCode == "Cyrl")
+    #expect(lang5.name == "Kazakh")
+    
+    let lang6 = try W3WRfcLanguage(code: "kk", iOSCompatible: true)
+    #expect(lang6.code == "kk")
+    #expect(lang6.name == "Kazakh")
+  }
+  
+  /// List of our current w3w languages
+  /// with the check iOS compatible, all languages except exceptions will be init successfully
+  @Test(arguments: [
+    "af", "am", "ar", "bn", "bs-Cyrl", "bs-Latn", "bg", "ca", "zh-Hant-HK",
+    "zh-Hant-TW", "zh-Hans", "hr", "cs", "da", "nl", "en-AU", "en-CA",
+    "en-GB", "en-IN", "en-US", "et", "fi", "fr-FR", "fr-CA", "de", "el",
+    "gu", "he", "hi", "hu", "id", "it", "ja", "kn", "kk-Cyrl", "kk-Latn",
+    "km", "ko", "lo", "ms", "ml", "mr", "mn-Cyrl", "mn-Latn", "sr-Cyrl-ME",
+    "sr-Latn-ME", "ne", "no", "or", "fa", "pl", "pt-PT", "pt-BR", "pa",
+    "ro", "ru", "sr-Cyrl-RS", "sr-Latn-RS", "si", "sk", "sl", "es-ES",
+    "es-MX", "sw", "sv", "ta", "te", "th", "tr", "uk", "ur", "vi", "cy",
+    "xh", "zu"
+])
+  func initRfcLanguage_fromW3WLanguages(lang: String) throws {
+    if exceptions.contains(lang) {
+      #expect(throws: W3WError.other(LanguageError.languageNotSupportedByOS)) {
+        _ = try W3WRfcLanguage(from: lang, iOSCompatible: true)
+      }
+    } else {
+      let rfcLanguage = try W3WRfcLanguage(from: lang, iOSCompatible: true)
+      print(lang)
+      #expect(rfcLanguage.code != nil)
+    }
   }
 }
 

--- a/Tests/languages-Tests/w3wRfcLanguage_tests.swift
+++ b/Tests/languages-Tests/w3wRfcLanguage_tests.swift
@@ -109,7 +109,7 @@ struct w3wRfcLanguage_tests {
     let lang6 = try W3WRfcLanguage(code: "kk", iOSCompatible: true)
     #expect(lang6.code == "kk")
     #expect(lang6.name == "Kazakh")
-  }
+}
   
   /// List of our current w3w languages
   /// with the check iOS compatible, all languages except exceptions will be init successfully
@@ -131,9 +131,30 @@ struct w3wRfcLanguage_tests {
       }
     } else {
       let rfcLanguage = try W3WRfcLanguage(from: lang, iOSCompatible: true)
-      print(lang)
       #expect(rfcLanguage.code != nil)
     }
+  }
+  
+  @Test(arguments: [
+    "af", "am", "ar", "bn", "bs-Cyrl", "bs-Latn", "bg", "ca", "zh-Hant-HK",
+    "zh-Hant-TW", "zh-Hans", "hr", "cs", "da", "nl", "en-AU", "en-CA",
+    "en-GB", "en-IN", "en-US", "et", "fi", "fr-FR", "fr-CA", "de", "el",
+    "gu", "he", "hi", "hu", "id", "it", "ja", "kn", "kk-Cyrl", "kk-Latn",
+    "km", "ko", "lo", "ms", "ml", "mr", "mn-Cyrl", "mn-Latn", "sr-Cyrl-ME",
+    "sr-Latn-ME", "ne", "no", "or", "fa", "pl", "pt-PT", "pt-BR", "pa",
+    "ro", "ru", "sr-Cyrl-RS", "sr-Latn-RS", "si", "sk", "sl", "es-ES",
+    "es-MX", "sw", "sv", "ta", "te", "th", "tr", "uk", "ur", "vi", "cy",
+    "xh", "zu"
+])
+  func initRfcLanguage_fromW3WLanguages_NoCompatibilityCheck(lang: String) throws {
+    let rfcLanguage = try W3WRfcLanguage(from: lang, iOSCompatible: false)
+    #expect(rfcLanguage.code != nil)
+    if exceptions.contains(lang) {
+      #expect(!rfcLanguage.iOSCompatible)
+    } else {
+      #expect(rfcLanguage.iOSCompatible)
+    }
+
   }
 }
 

--- a/Tests/languages-Tests/w3wRfcLanguage_tests.swift
+++ b/Tests/languages-Tests/w3wRfcLanguage_tests.swift
@@ -6,8 +6,8 @@
 //
 
 import Testing
+import Foundation
 @testable import W3WSwiftCore
-import w3w
 
 @Suite
 struct w3wRfcLanguage_tests {
@@ -22,8 +22,41 @@ struct w3wRfcLanguage_tests {
   
   @Test func initRfcLanguage_changeDefault() async throws {
     let lang = W3WRfcLanguage(locale: Locale(identifier: "fr-FR"))
-    W3WRfcLanguage.default = W3WRfcLanguage(from: "de")
     #expect(lang.code == "fr")
-    #expect(lang.name == "Französisch (Frankreich)")
+  }
+  
+  @Test func initRfcLanguage_Exceptions_Mongolian() async throws {
+    let lang1 = W3WRfcLanguage(from: "mn-Latn")
+    #expect(lang1.code == "mn")
+    #expect(lang1.name == "Mongolian")
+    #expect(lang1.scriptCode == "Latn")
+    
+    let lang2 = W3WRfcLanguage(from: "mn-Cyrl")
+    #expect(lang2.code == "mn")
+    #expect(lang2.name == "Mongolian")
+    #expect(lang2.scriptCode == "Cyrl")
+    
+    let lang3 = W3WRfcLanguage(from: "mn")
+    #expect(lang3.code == "mn")
+    #expect(lang3.name == "Mongolian")
+    #expect(lang3.scriptCode == "Cyrl")
+  }
+  
+  @Test func initRfcLanguage_Exceptions_Kazakh() async throws {
+    let lang1 = W3WRfcLanguage(from: "kk-Cyrl")
+    #expect(lang1.code == "kk")
+    #expect(lang1.name == "Kazakh")
+    #expect(lang1.scriptCode == "Cyrl")
+    
+    let lang2 = W3WRfcLanguage(from: "kk-Latn")
+    #expect(lang2.code == "kk")
+    #expect(lang2.name == "Kazakh")
+    #expect(lang2.scriptCode == "Latn")
+    
+    let lang3 = W3WRfcLanguage(from: "kk")
+    #expect(lang3.code == "kk")
+    #expect(lang3.name == "Kazakh")
+    #expect(lang3.scriptCode == "Cyrl")
   }
 }
+


### PR DESCRIPTION
**Context**: Some w3w languages are not supported by OS (kk-Latn, mn-Latn, etc...). So we wont be able to init W3WRfcLanguage from those codes 

**Update**: 
- Removed check `isValidLocale` in `init(from: String)`
- Update logic check `isValidLocale`
- Introduced 2 new interfaces that takes `iOSCompatible`. If `iOSCompatible = true` we will validate whether its a valid language supported by iOS before initiation. They will throw `LanguageError.languageNotSupportedByOS` if the init fails
- Added `iOSCompatible` to W3WRfcLanguageProtocol