### PR TITLE
move exceptionalCases out of W3WRfcLanguageProtocol

### DIFF
--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocol.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocol.swift
@@ -72,11 +72,6 @@ public extension W3WRfcLanguageProtocol {
   }
 }
 
-public extension W3WRfcLanguageProtocol {
-  ///Exceptional cases
-  var exceptionalCases: [String: String] { return [:] }
-}
-
 public enum LanguageError: Error {
   case languageNotSupportedByOS
 }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 public protocol W3WLanguageSelectionProtocol {
-  ///Exceptional cases
-  var exceptionalCases: [String: String] { get }
   /// to set RFCLanguage
   func set(language: any W3WRfcLanguageProtocol)
 }
 
 /// list out all available RFCLanguages
 public protocol W3WAvailableLanguageProtocol {
+  ///Exceptional cases
+  var exceptionalCases: [String: String] { get }
   func availableLanguages() -> [W3WRfcLanguage]
 }
 
@@ -23,5 +23,9 @@ public extension W3WAvailableLanguageProtocol {
   /// default convenience func for available languages, should override when in need
   func availableLanguages() -> [W3WRfcLanguage] {
     return []
+  }
+  
+  var exceptionalCases: [String: String] {
+    return [:]
   }
 }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
@@ -24,7 +24,7 @@ public extension W3WAvailableLanguageProtocol {
   }
 }
 
-public protocol W3WExceptionalLanguagesProtocol {
+public protocol W3WExceptionalLanguageProtocol {
   ///Exceptional cases
   var exceptionalCases: [String: String] { get }
 }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-public protocol W3WLanguageSelectionProtocol  {
+public protocol W3WLanguageSelectionProtocol {
+  ///Exceptional cases
+  var exceptionalCases: [String: String] { get }
   /// to set RFCLanguage
   func set(language: any W3WRfcLanguageProtocol)
 }

--- a/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
+++ b/Sources/W3WSwiftCore/RfcLanguage/W3WRfcLanguageProtocols.swift
@@ -14,8 +14,6 @@ public protocol W3WLanguageSelectionProtocol {
 
 /// list out all available RFCLanguages
 public protocol W3WAvailableLanguageProtocol {
-  ///Exceptional cases
-  var exceptionalCases: [String: String] { get }
   func availableLanguages() -> [W3WRfcLanguage]
 }
 
@@ -24,8 +22,9 @@ public extension W3WAvailableLanguageProtocol {
   func availableLanguages() -> [W3WRfcLanguage] {
     return []
   }
-  
-  var exceptionalCases: [String: String] {
-    return [:]
-  }
+}
+
+public protocol W3WExceptionalLanguagesProtocol {
+  ///Exceptional cases
+  var exceptionalCases: [String: String] { get }
 }


### PR DESCRIPTION
This PR is to move `exceptionalCases` out of `W3WRfcLanguageProtocol`