### PR TITLE
Release w3w-swift-core v1.3.0

### DIFF
--- a/Sources/W3WSwiftCore/Network/W3WJson.swift
+++ b/Sources/W3WSwiftCore/Network/W3WJson.swift
@@ -20,4 +20,9 @@ public class W3WJson<CodableType: Codable> {
     return nil
   }
   
+  
+  static public func decode(json: Data) throws -> CodableType {
+    return try JSONDecoder().decode(CodableType.self, from: json)
+  }
+  
 }

--- a/Sources/W3WSwiftCore/Network/W3WRequest.swift
+++ b/Sources/W3WSwiftCore/Network/W3WRequest.swift
@@ -145,13 +145,25 @@ open class W3WRequest {
    - parameter params: dictionary of parameters to send on querystring
    - parameter completion: The completion handler
    */
-  @available(iOS 15.0, *)
-  public func call<T: Codable>(path: String, params: [String:String]? = nil, json: [String:Any]? = nil, method: W3WRequestMethod = .get) async throws -> T {
+  @available(iOS 13.0, watchOS 6.0, *)
+  public func call<T: Codable>(path: String, params: [String:String]? = nil, json: [String:Any]? = nil, postVars: [String:String] = [:], method: W3WRequestMethod = .get) async throws -> T {
     // generate the request
-    if let request = makeRequest(path: path, params: params, json: json, method: method) {
-      
+    if var request = makeRequest(path: path, params: params, json: json, method: method) {
+
+      // if postVars are provided, encode them as a URL-encoded form body
+      if !postVars.isEmpty {
+        let bodyString = postVars.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }.joined(separator: "&")
+        request.httpBody = bodyString.data(using: .utf8)
+        request.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
+      }
+
       // Call the actual endpoint
-      let (data, metadata) = try await URLSession.shared.data(for: request)
+      let (data, metadata): (Data, URLResponse)
+      if #available(watchOS 8.0, *) {
+        (data, metadata) = try await URLSession.shared.data(for: request)
+      } else {
+        (data, metadata) = try await dataFallback(for: request)
+      }
 
       // deal with the results
       if let md = metadata as? HTTPURLResponse {
@@ -159,19 +171,51 @@ open class W3WRequest {
         // return results if good
         if md.statusCode == 200 {
           return try W3WJson<T>.decode(json: data)
-          
-        // if the gttp code is anything but 200 return it in an error
+
+        // if the http code is anything but 200 return it in an error
         } else {
           throw W3WError.code(md.statusCode, "HTTP Error \(md.statusCode)")
         }
       }
     }
 
-    // if we made it here, sometning went wrong with the request
+    // if we made it here, something went wrong with the request
     throw W3WError.message("bad request")
   }
-  
-  
+
+
+  /**
+   Calls w3w URL with async, discarding the response body.
+   Throws on non-200 status codes.
+   - parameter path: The URL to call
+   - parameter params: dictionary of parameters to send on querystring
+   - parameter json: dictionary to send as JSON body
+   - parameter method: HTTP method
+   */
+  @available(iOS 13.0, watchOS 6.0, *)
+  public func call(path: String, params: [String:String]? = nil, json: [String:Any]? = nil, postVars: [String:String] = [:], method: W3WRequestMethod = .get) async throws {
+    let _: W3WEmptyResponse = try await call(path: path, params: params, json: json, postVars: postVars, method: method)
+  }
+
+
+  /// Fallback for platforms where `URLSession.data(for:)` is unavailable (e.g. watchOS < 8).
+  @available(iOS 13.0, watchOS 6.0, *)
+  private func dataFallback(for request: URLRequest) async throws -> (Data, URLResponse) {
+    return try await withCheckedThrowingContinuation { continuation in
+      let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else if let data = data, let response = response {
+          continuation.resume(returning: (data, response))
+        } else {
+          continuation.resume(throwing: W3WError.message("Unknown network error"))
+        }
+      }
+      task.resume()
+    }
+  }
+
+
   /**
    given a path and parameters, make a URLRequest object
    - parameter path: The URL to call
@@ -309,5 +353,14 @@ open class W3WRequest {
   public func publicMakeRequest(path: String, params: [String:String]? = nil, json: [String:Any]? = nil, method: W3WRequestMethod = .get) -> URLRequest? {
       return makeRequest(path: path, params: params, json: json, method: method)
   }
-  
+
 }
+
+
+/// A Codable type that decodes from any JSON (or empty body), used by the void call() overload
+private struct W3WEmptyResponse: Codable {
+  init() { }
+  init(from decoder: Decoder) throws { }
+  func encode(to encoder: Encoder) throws { }
+}
+

--- a/Sources/W3WSwiftCore/Network/W3WRequest.swift
+++ b/Sources/W3WSwiftCore/Network/W3WRequest.swift
@@ -140,6 +140,39 @@ open class W3WRequest {
   
   
   /**
+   Calls w3w URL with async
+   - parameter path: The URL to call
+   - parameter params: dictionary of parameters to send on querystring
+   - parameter completion: The completion handler
+   */
+  @available(iOS 15.0, *)
+  public func call<T: Codable>(path: String, params: [String:String]? = nil, json: [String:Any]? = nil, method: W3WRequestMethod = .get) async throws -> T {
+    // generate the request
+    if let request = makeRequest(path: path, params: params, json: json, method: method) {
+      
+      // Call the actual endpoint
+      let (data, metadata) = try await URLSession.shared.data(for: request)
+
+      // deal with the results
+      if let md = metadata as? HTTPURLResponse {
+
+        // return results if good
+        if md.statusCode == 200 {
+          return try W3WJson<T>.decode(json: data)
+          
+        // if the gttp code is anything but 200 return it in an error
+        } else {
+          throw W3WError.code(md.statusCode, "HTTP Error \(md.statusCode)")
+        }
+      }
+    }
+
+    // if we made it here, sometning went wrong with the request
+    throw W3WError.message("bad request")
+  }
+  
+  
+  /**
    given a path and parameters, make a URLRequest object
    - parameter path: The URL to call
    - parameter params: disctionary of parameters to send on querystring

--- a/Sources/W3WSwiftCore/Network/W3WRequest.swift
+++ b/Sources/W3WSwiftCore/Network/W3WRequest.swift
@@ -152,9 +152,14 @@ open class W3WRequest {
 
       // if postVars are provided, encode them as a URL-encoded form body
       if !postVars.isEmpty {
-        let bodyString = postVars.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }.joined(separator: "&")
-        request.httpBody = bodyString.data(using: .utf8)
+        request.httpBody = formEncode(postVars)
         request.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
+      }
+
+      // DEBUG: dump full request
+      if path.contains("saved-location-lists") {
+        print("DEBUG request: \(request.httpMethod ?? "?") \(request.url?.absoluteString ?? "?")")
+        print("DEBUG headers: \(request.allHTTPHeaderFields ?? [:])")
       }
 
       // Call the actual endpoint
@@ -169,13 +174,12 @@ open class W3WRequest {
       if let md = metadata as? HTTPURLResponse {
 
         // return results if good
-        if md.statusCode == 200 {
-          return try W3WJson<T>.decode(json: data)
-
-        // if the http code is anything but 200 return it in an error
-        } else {
-          throw W3WError.code(md.statusCode, "HTTP Error \(md.statusCode)")
+        guard (200..<300).contains(md.statusCode) else {
+          let body = String(data: data, encoding: .utf8) ?? ""
+          throw W3WError.code(md.statusCode, "HTTP Error \(md.statusCode): \(body)")
         }
+
+        return try W3WJson<T>.decode(json: data)
       }
     }
 
@@ -243,8 +247,6 @@ open class W3WRequest {
     
     // create the URL
     if let url = urlComponents.url {
-      // DEBUG
-      //print("calling: ", url)
       
       // create the request
       var request = URLRequest(url: url)
@@ -270,6 +272,21 @@ open class W3WRequest {
   }
   
   
+  /// Encode a dictionary as an application/x-www-form-urlencoded body (RFC 3986 unreserved characters only)
+  func formEncode(_ params: [String: String]) -> Data {
+    var allowed = CharacterSet.alphanumerics
+    allowed.insert(charactersIn: "-._~")
+
+    let encoded = params.map { key, value in
+      let k = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
+      let v = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+      return "\(k)=\(v)"
+    }.joined(separator: "&")
+
+    return encoded.data(using: .utf8) ?? Data()
+  }
+
+
   /**
    Calls w3w URL
    - parameter data: the returned data from the API

--- a/Sources/W3WSwiftCore/Reactive/W3WLive.swift
+++ b/Sources/W3WSwiftCore/Reactive/W3WLive.swift
@@ -13,3 +13,13 @@ import Combine
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
 public typealias W3WLive<T> = CurrentValueSubject<T, Never>
 
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+public extension W3WLive {
+  
+  /// trigger an event using the current value
+  func send() {
+    send(value)
+  }
+  
+}

--- a/Sources/W3WSwiftCore/Types/Util/LanguageUtils.swift
+++ b/Sources/W3WSwiftCore/Types/Util/LanguageUtils.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 public class LanguageUtils {
+  
   /// gets the langauge name for a locale in the language specified by 'inLocale'
   /// Parameters
   ///   - forLocale: locale to find the language of
@@ -25,6 +26,18 @@ public class LanguageUtils {
     
     return languageName
   }
+  
+  
+  public static func availableLanguages() -> [any W3WRfcLanguageProtocol] {
+    var languages = [W3WRfcLanguage]()
+    
+    for language in Locale.availableIdentifiers {
+      languages.append(W3WRfcLanguage(from: language))
+    }
+    
+    return languages
+  }
+  
 }
 
 extension String {


### PR DESCRIPTION
## Summary

Promotes `staging` into `main` to cut release **v1.3.0** (minor bump from v1.2.0).

### What's included
- Added async `call()` and async `W3WRequest` method (async URLRequest support).
- Minor additions in `W3WLive.swift` (Reactive) and `LanguageUtils.swift`.

### Scope
3 commits, 4 files changed (+134 / -3).